### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/v1/production/database-resource/template/deployment.yaml
+++ b/v1/production/database-resource/template/deployment.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
         - name: pgpool
-          image: bitnami/pgpool:latest
+          image: soldevelo/pgpool:latest
           envFrom:
             - configMapRef:
                 name: bao-${DEPLOY_ENV}-config


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/pgpool:latest` → [`soldevelo/pgpool:latest`](https://hub.docker.com/r/soldevelo/pgpool)